### PR TITLE
remove scipy dependency and fix numpy version issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requires = [
     "viser",
     "nerfview @ git+https://github.com/RongLiu-Leo/nerfview.git",
     "imageio[ffmpeg]",
-    "numpy<2.0.0",
+    "numpy",
     "scikit-learn",
     "tqdm",
     "torchmetrics[image]",

--- a/utils/camera_utils.py
+++ b/utils/camera_utils.py
@@ -14,7 +14,6 @@ from utils.general_utils import PILtoTorch
 from utils.graphics_utils import fov2focal
 import torch
 import numpy as np
-import scipy
 import copy
 
 WARNED = False


### PR DESCRIPTION
numpy<2.0.0 will cause the following conflict with torch:

```
Found transforms_train.json file, assuming Blender data set! [21/06 01:05:04]
Reading Training Transforms [21/06 01:05:04]
Reading Test Transforms [21/06 01:05:06]
Loading Training Cameras [21/06 01:05:10]
Traceback (most recent call last):
  File "/home/dylan/Documents/Researches/beta-splatting/train.py", line 260, in <module>
    training(args)
  File "/home/dylan/Documents/Researches/beta-splatting/train.py", line 35, in training
    scene = Scene(args, beta_model)
  File "/home/dylan/Documents/Researches/beta-splatting/scene/__init__.py", line 98, in __init__
    self.train_cameras[resolution_scale] = cameraList_from_camInfos(
  File "/home/dylan/Documents/Researches/beta-splatting/utils/camera_utils.py", line 75, in cameraList_from_camInfos
    camera_list.append(loadCam(args, id, c, resolution_scale))
  File "/home/dylan/Documents/Researches/beta-splatting/utils/camera_utils.py", line 49, in loadCam
    resized_image_rgb = PILtoTorch(cam_info.image, resolution)
  File "/home/dylan/Documents/Researches/beta-splatting/utils/general_utils.py", line 27, in PILtoTorch
    resized_image = torch.from_numpy(np.array(resized_image_PIL)) / 255.0
TypeError: expected np.ndarray (got numpy.ndarray)
```

since `scipy` not used anywhere anymore, removed its dependency (which is the one needs older numpy)