### PR TITLE
Fix torch.multinomial() 2^24 limit using chunked sampling

### DIFF
--- a/scene/beta_model.py
+++ b/scene/beta_model.py
@@ -718,13 +718,80 @@ class BetaModel:
             self._rotation[idxs],
         )
 
+    # Fixed torch.multinomial() 2^24 limit using chunked sampling
+    # Handles distributions with >16.7M elements (FP32 precision constraint)
+    # Maintains same interface - drop-in replacement
     def _sample_alives(self, probs, num, alive_indices=None):
         probs = probs / (probs.sum() + torch.finfo(torch.float32).eps)
-        sampled_idxs = torch.multinomial(probs, num, replacement=True)
+        
+        # PyTorch multinomial limit
+        MAX_CATEGORIES = 2**24 - 1
+        
+        if len(probs) <= MAX_CATEGORIES:
+            # Original implementation for smaller cases
+            sampled_idxs = torch.multinomial(probs, num, replacement=True)
+        else:
+            # Chunked sampling for large cases
+            sampled_idxs = []
+            remaining_samples = num
+            current_start_idx = 0  
+            
+            # Pre-calculate chunk weights for proportional allocation
+            chunk_weights = []
+            temp_start = 0
+            while temp_start < len(probs):
+                chunk_end = min(temp_start + MAX_CATEGORIES, len(probs))
+                chunk_weight = probs[temp_start:chunk_end].sum().item()
+                chunk_weights.append(chunk_weight)
+                temp_start = chunk_end
+            
+            total_weight = sum(chunk_weights)
+            chunk_idx = 0
+            
+            while remaining_samples > 0 and current_start_idx < len(probs):
+                # Calculate chunk boundaries
+                chunk_end = min(current_start_idx + MAX_CATEGORIES, len(probs))
+                chunk_probs = probs[current_start_idx:chunk_end]
+                
+                # Calculate how many samples this chunk should get
+                if chunk_idx < len(chunk_weights) - 1:
+                    # Proportional allocation for non-last chunks
+                    chunk_samples = int(num * chunk_weights[chunk_idx] / total_weight)
+                else:
+                    # Give all remaining samples to the last chunk 
+                    chunk_samples = remaining_samples
+                
+                chunk_samples = min(chunk_samples, remaining_samples)
+                
+                if chunk_samples > 0:
+                    # Normalize chunk probabilities
+                    chunk_probs_norm = chunk_probs / (chunk_probs.sum() + torch.finfo(torch.float32).eps)
+                    
+                    # Sample from chunk (LOCAL indices)
+                    local_sampled = torch.multinomial(chunk_probs_norm, chunk_samples, replacement=True)
+                    
+                    # Convert to GLOBAL indices
+                    global_sampled = local_sampled + current_start_idx
+                    sampled_idxs.append(global_sampled)
+                
+                # Move to next chunk
+                current_start_idx = chunk_end
+                remaining_samples -= chunk_samples
+                chunk_idx += 1
+            
+            sampled_idxs = torch.cat(sampled_idxs) if sampled_idxs else torch.empty(0, dtype=torch.long, device=probs.device)
+        
         if alive_indices is not None:
             sampled_idxs = alive_indices[sampled_idxs]
-        ratio = torch.bincount(sampled_idxs)[sampled_idxs]
+        
+        # Calculate ratio with proper length
+        if alive_indices is not None:
+            ratio = torch.bincount(sampled_idxs, minlength=len(alive_indices))[sampled_idxs]
+        else:
+            ratio = torch.bincount(sampled_idxs, minlength=len(probs))[sampled_idxs]
+        
         return sampled_idxs, ratio
+    
 
     def relocate_gs(self, dead_mask=None):
         print(f"Relocate: {dead_mask.sum().item()}")


### PR DESCRIPTION
## Fix torch.multinomial() sampling beyond 2²⁴ limit

### Problem
`torch.multinomial()` fails when sampling from distributions with >2²⁴ (~16.7M) elements due to FP32 mantissa precision limits (24-bit). This becomes a bottleneck in city-scale scenes with 30M+ splats.

### Solution
Implemented chunked sampling approach that:
- Splits large distributions into chunks of size ≤2²⁴-1
- Normalizes probabilities within each chunk
- Performs standard multinomial sampling per chunk
- Maps local indices back to global space

### Implementation
- Drop-in replacement (same function signature)
- No changes needed in calling code

### Validaion
- Tested with ~40M splats during my work at Dronodat GmBH
- No OOM errors, no precision loss

### Changes
- Modified: `scene/beta_model.py` function `_sample_alives()`
- Added chunking logic (~70 lines with comments)

*Note: For city-scale scenes, we also reduced `noise_lr` from default 5e4 to near-zero for training stability - this is separate from the multinomial fix but worth noting for large-scale users.*